### PR TITLE
Add option to prevent CSS directory cleanup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,6 +106,27 @@ process.on('SIGINT', () => {
 });
 ```
 
+### Preventing CSS directory cleanup
+
+```js
+const compileSass = require('compile-sass');
+const preventCssCleanup = true;
+compileSass.compileSassAndSave('full/path/to/sass-file.scss', 'full/path/to/css/', preventCssCleanup)
+  .then(...)
+  .catch(...);
+```
+
+```js
+const compileSass = require('compile-sass');
+const preventCssCleanup = true;
+compileSass.compileSassAndSaveMultiple({
+    sassPath: path.join(__dirname, 'public/scss/'),
+    cssPath: path.join(__dirname, 'public/css/'),
+    files: ['libs.scss'],
+    preventCssCleanup
+  });
+}).then(...).catch(...);
+```
 
 ## Maintainer
 

--- a/Readme.md
+++ b/Readme.md
@@ -108,6 +108,8 @@ process.on('SIGINT', () => {
 
 ### Preventing CSS directory cleanup
 
+To prevent the CSS directory from being deleted, add `preventCssCleanup` to the compile and save calls.
+
 ```js
 const compileSass = require('compile-sass');
 const preventCssCleanup = true;

--- a/index.js
+++ b/index.js
@@ -80,13 +80,15 @@ function compileSass(fullSassPath) {
 }
 
 
-function compileSassAndSave(fullSassPath, cssPath) {
+function compileSassAndSave(fullSassPath, cssPath, preventCssCleanup = false) {
   const sassFile = fullSassPath.match(/[ \w-]+[.]+[\w]+$/)[0];
   const sassFileExt = sassFile.match(/\.[0-9a-z]+$/i)[0];
   const cssFile = sassFile.replace(sassFileExt, '.css');
   const fullCssPath = path.join(cssPath, cssFile);
 
-  setupCleanupOnExit(cssPath);
+  if (!preventCssCleanup) {
+    setupCleanupOnExit(cssPath);
+  }
 
   return compileSass(fullSassPath).then(css => {
     return new Promise((resolve, reject) => {
@@ -116,17 +118,19 @@ function compileSassAndSave(fullSassPath, cssPath) {
 OPTIONS: {
     sassPath,
     cssPath,
-    files
+    files,
+    preventCssCleanup
   }
 */
 
 function compileSassAndSaveMultiple(options) {
   const sassPath = options.sassPath;
   const cssPath = options.cssPath;
+  const preventCssCleanup = options.preventCssCleanup || false;
 
   return new Promise((resolve, reject) => {
     options.files.forEach(sassFile => {
-      compileSassAndSave(path.join(sassPath, sassFile), cssPath).then(cssFile => {
+      compileSassAndSave(path.join(sassPath, sassFile, preventCssCleanup), cssPath).then(cssFile => {
         console.log('Created', cssFile);
       }).catch(error => {
         reject(error);


### PR DESCRIPTION
I'm using your project to pull out pieces of my SCSS to be included inline with pieces of my project that can be embedded and need just their piece of styling. However, I need to retain these additional CSS files. I'm proposing the following edits, which I'm using to accomplish this.