### PR TITLE
Prevent command injection when calling setupCleanupOnExit in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,12 +177,12 @@ export function setupCleanupOnExit(cssPath: string) {
 
       fs.lstat(cssPath, (error: Error, stats: fs.Stats): void => {
         if (stats.isDirectory) {
-          exec(`rm -r ${cssPath}`, function(error) {
+          fs.rmdirSync(cssPath, { recursive: true }, (error) => {
             if (error) {
               console.error(error);
               process.exit(1);
             }
-    
+
             console.log('Deleted CSS files');
           });
         }


### PR DESCRIPTION
Prevent command injection when calling `setupCleanupOnExit` in `index.ts`.
Otherwise, arbitrary command can be run. For example, if `cssPath` is `/ ; rm -rf /`, It will run `rm -r /` and then `rm -rf /`.